### PR TITLE
Switch to GEMINI_API_KEY env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,14 @@ A powerful, intuitive tool for TTRPG Game Masters to generate unique, structured
 ### Prerequisites
 
 *   A modern web browser that supports ES6 modules and `importmap`.
-*   An API key for the Google Gemini API. This key must be available as an environment variable named `API_KEY` in the execution environment. The application is designed to read this key directly from the environment.
+*   An API key for the Google Gemini API. This key must be available as an environment variable named `GEMINI_API_KEY` in the execution environment. The application is designed to read this key directly from the environment.
 
 ### Running the Application
 
 This is a frontend-only application that can be run by serving its files with a local web server.
 
 1.  Clone or download the project files.
-2.  Ensure the `API_KEY` environment variable is set in the terminal session you will use to launch the server. The application code expects this to be available at runtime.
+2.  Ensure the `GEMINI_API_KEY` environment variable is set in the terminal session you will use to launch the server. The application code expects this to be available at runtime.
 3.  From the project's root directory, start a simple local web server (e.g., `python -m http.server` or `npx serve`).
 4.  Open the local server's URL in your browser (e.g., `http://localhost:8000`).
 

--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -22,17 +22,17 @@ import { MAGIC_ITEM_DNA_DECODING_PROMPT } from './prompts/magicItemPrompt';
 import { TRAVEL_DNA_DECODING_PROMPT } from './prompts/travelPrompt';
 
 
-const API_KEY = process.env.API_KEY;
+const API_KEY = process.env.GEMINI_API_KEY;
 
 if (!API_KEY) {
-    console.error("API_KEY environment variable not set.");
+    console.error("GEMINI_API_KEY environment variable not set.");
 }
 
 const ai = new GoogleGenAI({ apiKey: API_KEY! });
 
 const generateGeminiContent = async (prompt: string): Promise<string> => {
     if (!API_KEY) {
-        throw new Error("API_KEY is not configured. Please set the environment variable.");
+        throw new Error("GEMINI_API_KEY is not configured. Please set the environment variable.");
     }
     try {
         console.groupCollapsed('--- GEMINI API CALL ---');

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,6 @@ export default defineConfig(({ mode }) => {
     const env = loadEnv(mode, '.', '');
     return {
       define: {
-        'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
         'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY)
       },
       resolve: {


### PR DESCRIPTION
## Summary
- update docs to use `GEMINI_API_KEY`
- read `process.env.GEMINI_API_KEY` in gemini service
- only expose `GEMINI_API_KEY` in Vite config

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f302f1cf8832b8e67bce3199dc131