### PR TITLE
Clarify GEMINI_API_KEY usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,10 @@ A powerful, intuitive tool for TTRPG Game Masters to generate unique, structured
 This is a frontend-only application that can be run by serving its files with a local web server.
 
 1.  Clone or download the project files.
-2.  Ensure the `GEMINI_API_KEY` environment variable is set in the terminal session you will use to launch the server. The application code expects this to be available at runtime.
+2.  Ensure the `GEMINI_API_KEY` environment variable is set in the terminal session you will use to launch the server. The application code expects this to be available at runtime. For example:
+    ```bash
+    export GEMINI_API_KEY=your-google-gemini-key
+    ```
 3.  From the project's root directory, start a simple local web server (e.g., `python -m http.server` or `npx serve`).
 4.  Open the local server's URL in your browser (e.g., `http://localhost:8000`).
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,7 @@ import { defineConfig, loadEnv } from 'vite';
 export default defineConfig(({ mode }) => {
     const env = loadEnv(mode, '.', '');
     return {
+      // Expose the Gemini API key so the client can access it at runtime
       define: {
         'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY)
       },


### PR DESCRIPTION
## Summary
- document how to set GEMINI_API_KEY in the README
- add a comment in `vite.config.ts` explaining the exposed environment variable

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686f36c271c0832ba842a2c9b8825abb