### PR TITLE
Add typed form data for GenerationForm

### DIFF
--- a/components/GenerationForm.tsx
+++ b/components/GenerationForm.tsx
@@ -1,6 +1,11 @@
 
 import React, { useState } from 'react';
-import { ContentType, GenerationMethod, ContentItem } from '../types';
+import {
+    ContentType,
+    GenerationMethod,
+    ContentItem,
+    DetailedFormData,
+} from '../types';
 import { useProject } from '../contexts/ProjectContext';
 import { generateItem } from '../services/geminiService';
 import Button from './common/Button';
@@ -26,11 +31,16 @@ const GenerationForm: React.FC<GenerationFormProps> = ({ type, onGenerate, setIs
     const { project } = useProject();
     const [method, setMethod] = useState<GenerationMethod>(generationContext ? GenerationMethod.Guided : GenerationMethod.Random);
     const [guidance, setGuidance] = useState(generationContext?.guidance || '');
-    const [formData, setFormData] = useState<any>({});
+    const [formData, setFormData] = useState<DetailedFormData>({});
 
-    const handleFormChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
+    const handleFormChange = (
+        e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>
+    ) => {
         const { name, value } = e.target;
-        setFormData((prev: any) => ({ ...prev, [name]: value }));
+        setFormData((prev) => ({
+            ...prev,
+            [name as keyof DetailedFormData]: value,
+        }));
     };
 
     const handleSubmit = async (e: React.FormEvent) => {

--- a/types.ts
+++ b/types.ts
@@ -180,3 +180,14 @@ export interface TravelFormData {
     preference?: string;
     extraContext?: string;
 }
+
+// A union of all detailed form fields used for generation
+export type DetailedFormData = Partial<
+    WorldFormData &
+    NpcFormData &
+    FactionFormData &
+    QuestFormData &
+    SettlementFormData &
+    MagicItemFormData &
+    TravelFormData
+>;


### PR DESCRIPTION
## Summary
- add `DetailedFormData` union to `types.ts`
- type form state in `GenerationForm` with `DetailedFormData`
- update change handler to use typed keys

## Testing
- `npm run build` *(fails: vite not found)*
- `npx tsc --noEmit` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_686f36c641f4832b97792db4b7fbfeea